### PR TITLE
Prevent SQL injection

### DIFF
--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -38,9 +38,9 @@ func Conn() (db *sqlx.DB) {
 }
 
 // WhereByRequest create interface for queries + where
-func WhereByRequest(r *http.Request) (whereSyntax string, values []string) {
+func WhereByRequest(r *http.Request) (whereSyntax map[string]string) {
+	whereSyntax = make(map[string]string)
 	u, _ := url.Parse(r.URL.String())
-	where := []string{}
 	for key, val := range u.Query() {
 		if !strings.HasPrefix(key, "_") {
 			keyInfo := strings.Split(key, ":")
@@ -48,21 +48,16 @@ func WhereByRequest(r *http.Request) (whereSyntax string, values []string) {
 				switch keyInfo[1] {
 				case "jsonb":
 					jsonField := strings.Split(keyInfo[0], "->>")
-					where = append(where, fmt.Sprintf("%s->>'%s'=?", jsonField[0], jsonField[1]))
-					values = append(values, val[0])
+					whereSyntax[fmt.Sprintf("%s->>'%s'=?", jsonField[0], jsonField[1])] = val[0]
 				default:
-					where = append(where, fmt.Sprintf("%s=?", keyInfo[0]))
-					values = append(values, val[0])
+					whereSyntax[fmt.Sprintf("%s=?", keyInfo[0])] = val[0]
 				}
 				continue
 			}
-			where = append(where, fmt.Sprintf("%s=?", key))
-			values = append(values, val[0])
-
+			whereSyntax[fmt.Sprintf("%s=?", key)] = val[0]
 		}
 	}
 
-	whereSyntax = strings.Join(where, " and ")
 	return
 }
 

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -38,7 +38,7 @@ func Conn() (db *sqlx.DB) {
 }
 
 // WhereByRequest create interface for queries + where
-func WhereByRequest(r *http.Request) (whereSyntax string) {
+func WhereByRequest(r *http.Request) (whereSyntax string, values []string) {
 	u, _ := url.Parse(r.URL.String())
 	where := []string{}
 	for key, val := range u.Query() {
@@ -48,14 +48,17 @@ func WhereByRequest(r *http.Request) (whereSyntax string) {
 				switch keyInfo[1] {
 				case "jsonb":
 					jsonField := strings.Split(keyInfo[0], "->>")
-					where = append(where, fmt.Sprintf("%s->>'%s'='%s'", jsonField[0], jsonField[1], val[0]))
+					where = append(where, fmt.Sprintf("%s->>'%s'=?", jsonField[0], jsonField[1]))
+					values = append(values, val[0])
 				default:
-					where = append(where, fmt.Sprintf("%s='%s'", keyInfo[0], val[0]))
-
+					where = append(where, fmt.Sprintf("%s=?", keyInfo[0]))
+					values = append(values, val[0])
 				}
 				continue
 			}
-			where = append(where, fmt.Sprintf("%s='%s'", key, val[0]))
+			where = append(where, fmt.Sprintf("%s=?", key))
+			values = append(values, val[0])
+
 		}
 	}
 

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/caarlos0/env"
 	"github.com/jmoiron/sqlx"
@@ -36,6 +37,24 @@ func Conn() (db *sqlx.DB) {
 		panic(fmt.Sprintf("Unable to connection to database: %v\n", err))
 	}
 	return
+}
+
+// chkInvaidIdentifier return true if identifier is invalid
+// https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+func chkInvaidIdentifier(identifer string) bool {
+	if len(identifer) > 63 ||
+		unicode.IsDigit([]rune(identifer)[0]) {
+		return true
+	}
+
+	for _, v := range identifer {
+		if !unicode.IsLetter(v) &&
+			!unicode.IsDigit(v) &&
+			v != '_' {
+			return true
+		}
+	}
+	return false
 }
 
 // WhereByRequest create interface for queries + where

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -71,7 +71,8 @@ func TestPaginateIfPossible(t *testing.T) {
 	Convey("Paginate if possible", t, func() {
 		r, err := http.NewRequest("GET", "/databases?dbname=prest&test=cool&_page=1&_page_size=20", nil)
 		So(err, ShouldBeNil)
-		where := PaginateIfPossible(r)
+		where, err := PaginateIfPossible(r)
+		So(err, ShouldBeNil)
 		So(where, ShouldContainSubstring, "LIMIT 20 OFFSET(1 - 1) * 20")
 	})
 }

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -1,7 +1,6 @@
 package postgres
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -13,11 +12,9 @@ func TestWhereByRequest(t *testing.T) {
 	Convey("Where by request without paginate", t, func() {
 		r, err := http.NewRequest("GET", "/databases?dbname=prest&test=cool", nil)
 		So(err, ShouldBeNil)
-		where, values := WhereByRequest(r, 1)
 
-		fmt.Println(where)
-		fmt.Println(values)
-
+		where, values, err := WhereByRequest(r, 1)
+		So(err, ShouldBeNil)
 		So(where, ShouldContainSubstring, "dbname=$")
 		So(where, ShouldContainSubstring, "test=$")
 		So(where, ShouldContainSubstring, " AND ")
@@ -28,15 +25,12 @@ func TestWhereByRequest(t *testing.T) {
 	Convey("Where by request with jsonb field", t, func() {
 		r, err := http.NewRequest("GET", "/prest/public/test?name=nuveo&data->>description:jsonb=bla", nil)
 		So(err, ShouldBeNil)
-		where, values := WhereByRequest(r, 1)
 
-		//fmt.Println(where)
-		//fmt.Println(values)
-
+		where, values, err := WhereByRequest(r, 1)
+		So(err, ShouldBeNil)
 		So(where, ShouldContainSubstring, "name=$")
 		So(where, ShouldContainSubstring, "data->>'description'=$")
 		So(where, ShouldContainSubstring, " AND ")
-
 		So(values, ShouldContain, "nuveo")
 		So(values, ShouldContain, "bla")
 	})

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -13,18 +14,20 @@ func TestWhereByRequest(t *testing.T) {
 		r, err := http.NewRequest("GET", "/databases?dbname=prest&test=cool", nil)
 		So(err, ShouldBeNil)
 		where := WhereByRequest(r)
-		So(where, ShouldContainSubstring, "dbname='prest'")
-		So(where, ShouldContainSubstring, "test='cool'")
-		So(where, ShouldContainSubstring, "and")
+
+		fmt.Println(where)
+		So(where["dbname=?"], ShouldEqual, "prest")
+		So(where["test=?"], ShouldEqual, "cool")
 	})
 
 	Convey("Where by request with jsonb field", t, func() {
 		r, err := http.NewRequest("GET", "/prest/public/test?name=nuveo&data->>description:jsonb=bla", nil)
 		So(err, ShouldBeNil)
 		where := WhereByRequest(r)
-		So(where, ShouldContainSubstring, "name='nuveo'")
-		So(where, ShouldContainSubstring, "data->>'description'='bla'")
-		So(where, ShouldContainSubstring, "and")
+
+		fmt.Println(where)
+		So(where["data->>'description'=?"], ShouldEqual, "bla")
+		So(where["name=?"], ShouldEqual, "nuveo")
 	})
 }
 

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -1,7 +1,6 @@
 package postgres
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -13,21 +12,28 @@ func TestWhereByRequest(t *testing.T) {
 	Convey("Where by request without paginate", t, func() {
 		r, err := http.NewRequest("GET", "/databases?dbname=prest&test=cool", nil)
 		So(err, ShouldBeNil)
-		where := WhereByRequest(r)
+		where, values := WhereByRequest(r)
 
-		fmt.Println(where)
-		So(where["dbname=?"], ShouldEqual, "prest")
-		So(where["test=?"], ShouldEqual, "cool")
+		//fmt.Println(where)
+		//fmt.Println(values)
+
+		So(where, ShouldEqual, "dbname=%1 AND test=%2")
+		So(values[0], ShouldEqual, "prest")
+		So(values[1], ShouldEqual, "cool")
 	})
 
 	Convey("Where by request with jsonb field", t, func() {
 		r, err := http.NewRequest("GET", "/prest/public/test?name=nuveo&data->>description:jsonb=bla", nil)
 		So(err, ShouldBeNil)
-		where := WhereByRequest(r)
+		where, values := WhereByRequest(r)
 
-		fmt.Println(where)
-		So(where["data->>'description'=?"], ShouldEqual, "bla")
-		So(where["name=?"], ShouldEqual, "nuveo")
+		//fmt.Println(where)
+		//fmt.Println(values)
+
+		So(where, ShouldEqual, "name=%1 AND data->>'description'=%2")
+
+		So(values[0], ShouldEqual, "nuveo")
+		So(values[1], ShouldEqual, "bla")
 	})
 }
 

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -12,12 +12,14 @@ func TestWhereByRequest(t *testing.T) {
 	Convey("Where by request without paginate", t, func() {
 		r, err := http.NewRequest("GET", "/databases?dbname=prest&test=cool", nil)
 		So(err, ShouldBeNil)
-		where, values := WhereByRequest(r)
+		where, values := WhereByRequest(r, 1)
 
 		//fmt.Println(where)
 		//fmt.Println(values)
 
-		So(where, ShouldEqual, "dbname=%1 AND test=%2")
+		So(where, ShouldContainSubstring, "dbname=$1")
+		So(where, ShouldContainSubstring, "test=$2")
+		So(where, ShouldContainSubstring, " AND ")
 		So(values[0], ShouldEqual, "prest")
 		So(values[1], ShouldEqual, "cool")
 	})
@@ -25,12 +27,14 @@ func TestWhereByRequest(t *testing.T) {
 	Convey("Where by request with jsonb field", t, func() {
 		r, err := http.NewRequest("GET", "/prest/public/test?name=nuveo&data->>description:jsonb=bla", nil)
 		So(err, ShouldBeNil)
-		where, values := WhereByRequest(r)
+		where, values := WhereByRequest(r, 1)
 
 		//fmt.Println(where)
 		//fmt.Println(values)
 
-		So(where, ShouldEqual, "name=%1 AND data->>'description'=%2")
+		So(where, ShouldContainSubstring, "name=$1")
+		So(where, ShouldContainSubstring, "data->>'description'=$2")
+		So(where, ShouldContainSubstring, " AND ")
 
 		So(values[0], ShouldEqual, "nuveo")
 		So(values[1], ShouldEqual, "bla")

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -14,14 +15,14 @@ func TestWhereByRequest(t *testing.T) {
 		So(err, ShouldBeNil)
 		where, values := WhereByRequest(r, 1)
 
-		//fmt.Println(where)
-		//fmt.Println(values)
+		fmt.Println(where)
+		fmt.Println(values)
 
-		So(where, ShouldContainSubstring, "dbname=$1")
-		So(where, ShouldContainSubstring, "test=$2")
+		So(where, ShouldContainSubstring, "dbname=$")
+		So(where, ShouldContainSubstring, "test=$")
 		So(where, ShouldContainSubstring, " AND ")
-		So(values[0], ShouldEqual, "prest")
-		So(values[1], ShouldEqual, "cool")
+		So(values, ShouldContain, "prest")
+		So(values, ShouldContain, "cool")
 	})
 
 	Convey("Where by request with jsonb field", t, func() {
@@ -32,12 +33,12 @@ func TestWhereByRequest(t *testing.T) {
 		//fmt.Println(where)
 		//fmt.Println(values)
 
-		So(where, ShouldContainSubstring, "name=$1")
-		So(where, ShouldContainSubstring, "data->>'description'=$2")
+		So(where, ShouldContainSubstring, "name=$")
+		So(where, ShouldContainSubstring, "data->>'description'=$")
 		So(where, ShouldContainSubstring, " AND ")
 
-		So(values[0], ShouldEqual, "nuveo")
-		So(values[1], ShouldEqual, "bla")
+		So(values, ShouldContain, "nuveo")
+		So(values, ShouldContain, "bla")
 	})
 }
 
@@ -90,7 +91,7 @@ func TestInsert(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	Convey("Delete data from table", t, func() {
-		json, err := Delete("prest", "public", "test", "name='nuveo'")
+		json, err := Delete("prest", "public", "test", "name=$1", []interface{}{"nuveo"})
 		So(err, ShouldBeNil)
 		So(len(json), ShouldBeGreaterThan, 0)
 	})
@@ -103,7 +104,7 @@ func TestUpdate(t *testing.T) {
 				"name": "prest",
 			},
 		}
-		json, err := Update("prest", "public", "test", "name='prest'", r)
+		json, err := Update("prest", "public", "test", "name=$1", []interface{}{"prest"}, r)
 		So(err, ShouldBeNil)
 		So(len(json), ShouldBeGreaterThan, 0)
 	})

--- a/controllers/databases.go
+++ b/controllers/databases.go
@@ -11,7 +11,12 @@ import (
 
 // GetDatabases list all (or filter) databases
 func GetDatabases(w http.ResponseWriter, r *http.Request) {
-	requestWhere, values := postgres.WhereByRequest(r, 1)
+	requestWhere, values, err := postgres.WhereByRequest(r, 1)
+	if err != nil {
+		log.Println(err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+
 	sqlDatabases := statements.Databases
 	if requestWhere != "" {
 		sqlDatabases = fmt.Sprint(

--- a/controllers/databases.go
+++ b/controllers/databases.go
@@ -22,7 +22,8 @@ func GetDatabases(w http.ResponseWriter, r *http.Request) {
 			statements.DatabasesOrderBy)
 	}
 	sqlDatabases = fmt.Sprint(sqlDatabases, " ", postgres.PaginateIfPossible(r))
-	object, err := postgres.Query(sqlDatabases, values)
+
+	object, err := postgres.Query(sqlDatabases, values...)
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/controllers/databases.go
+++ b/controllers/databases.go
@@ -15,6 +15,7 @@ func GetDatabases(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	sqlDatabases := statements.Databases

--- a/controllers/databases.go
+++ b/controllers/databases.go
@@ -21,7 +21,14 @@ func GetDatabases(w http.ResponseWriter, r *http.Request) {
 			requestWhere,
 			statements.DatabasesOrderBy)
 	}
-	sqlDatabases = fmt.Sprint(sqlDatabases, " ", postgres.PaginateIfPossible(r))
+
+	page, err := postgres.PaginateIfPossible(r)
+	if err != nil {
+		http.Error(w, "Paging error", http.StatusBadRequest)
+		return
+	}
+
+	sqlDatabases = fmt.Sprint(sqlDatabases, " ", page)
 
 	object, err := postgres.Query(sqlDatabases, values...)
 	if err != nil {

--- a/controllers/databases.go
+++ b/controllers/databases.go
@@ -11,7 +11,7 @@ import (
 
 // GetDatabases list all (or filter) databases
 func GetDatabases(w http.ResponseWriter, r *http.Request) {
-	requestWhere := postgres.WhereByRequest(r)
+	requestWhere, values := postgres.WhereByRequest(r, 1)
 	sqlDatabases := statements.Databases
 	if requestWhere != "" {
 		sqlDatabases = fmt.Sprint(
@@ -22,7 +22,7 @@ func GetDatabases(w http.ResponseWriter, r *http.Request) {
 			statements.DatabasesOrderBy)
 	}
 	sqlDatabases = fmt.Sprint(sqlDatabases, " ", postgres.PaginateIfPossible(r))
-	object, err := postgres.Query(sqlDatabases)
+	object, err := postgres.Query(sqlDatabases, values)
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/controllers/databases_test.go
+++ b/controllers/databases_test.go
@@ -14,20 +14,20 @@ func TestGetDatabases(t *testing.T) {
 		r, err := http.NewRequest("GET", "/databases", nil)
 		w := httptest.NewRecorder()
 		So(err, ShouldBeNil)
-		validate(w, r, GetDatabases)
+		validate(w, r, GetDatabases, "TestGetDatabases")
 	})
 
 	Convey("Get databases with custom where clause", t, func() {
 		r, err := http.NewRequest("GET", "/databases?datname=prest", nil)
 		w := httptest.NewRecorder()
 		So(err, ShouldBeNil)
-		validate(w, r, GetDatabases)
+		validate(w, r, GetDatabases, "TestGetDatabases")
 	})
 
 	Convey("Get databases with custom where clause and pagination", t, func() {
 		r, err := http.NewRequest("GET", "/databases?datname=prest&_page=1&_page_size=20", nil)
 		w := httptest.NewRecorder()
 		So(err, ShouldBeNil)
-		validate(w, r, GetDatabases)
+		validate(w, r, GetDatabases, "TestGetDatabases")
 	})
 }

--- a/controllers/schemas.go
+++ b/controllers/schemas.go
@@ -20,7 +20,14 @@ func GetSchemas(w http.ResponseWriter, r *http.Request) {
 			requestWhere,
 			statements.SchemasOrderBy)
 	}
-	sqlSchemas = fmt.Sprint(sqlSchemas, " ", postgres.PaginateIfPossible(r))
+
+	page, err := postgres.PaginateIfPossible(r)
+	if err != nil {
+		http.Error(w, "Paging error", http.StatusBadRequest)
+		return
+	}
+
+	sqlSchemas = fmt.Sprint(sqlSchemas, " ", page)
 	object, err := postgres.Query(sqlSchemas, values...)
 	if err != nil {
 		log.Println(err)

--- a/controllers/schemas.go
+++ b/controllers/schemas.go
@@ -21,7 +21,7 @@ func GetSchemas(w http.ResponseWriter, r *http.Request) {
 			statements.SchemasOrderBy)
 	}
 	sqlSchemas = fmt.Sprint(sqlSchemas, " ", postgres.PaginateIfPossible(r))
-	object, err := postgres.Query(sqlSchemas, values)
+	object, err := postgres.Query(sqlSchemas, values...)
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/controllers/schemas.go
+++ b/controllers/schemas.go
@@ -15,6 +15,7 @@ func GetSchemas(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	sqlSchemas := statements.Schemas

--- a/controllers/schemas.go
+++ b/controllers/schemas.go
@@ -11,7 +11,7 @@ import (
 
 // GetSchemas list all (or filter) schemas
 func GetSchemas(w http.ResponseWriter, r *http.Request) {
-	requestWhere := postgres.WhereByRequest(r)
+	requestWhere, values := postgres.WhereByRequest(r, 1)
 	sqlSchemas := statements.Schemas
 	if requestWhere != "" {
 		sqlSchemas = fmt.Sprint(
@@ -21,7 +21,7 @@ func GetSchemas(w http.ResponseWriter, r *http.Request) {
 			statements.SchemasOrderBy)
 	}
 	sqlSchemas = fmt.Sprint(sqlSchemas, " ", postgres.PaginateIfPossible(r))
-	object, err := postgres.Query(sqlSchemas)
+	object, err := postgres.Query(sqlSchemas, values)
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/controllers/schemas.go
+++ b/controllers/schemas.go
@@ -11,7 +11,12 @@ import (
 
 // GetSchemas list all (or filter) schemas
 func GetSchemas(w http.ResponseWriter, r *http.Request) {
-	requestWhere, values := postgres.WhereByRequest(r, 1)
+	requestWhere, values, err := postgres.WhereByRequest(r, 1)
+	if err != nil {
+		log.Println(err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+
 	sqlSchemas := statements.Schemas
 	if requestWhere != "" {
 		sqlSchemas = fmt.Sprint(

--- a/controllers/schemas_test.go
+++ b/controllers/schemas_test.go
@@ -13,20 +13,20 @@ func TestGetSchemas(t *testing.T) {
 		r, err := http.NewRequest("GET", "/schemas", nil)
 		w := httptest.NewRecorder()
 		So(err, ShouldBeNil)
-		validate(w, r, GetSchemas)
+		validate(w, r, GetSchemas, "TestGetSchemas")
 	})
 
 	Convey("Get schemas with custom where clause", t, func() {
 		r, err := http.NewRequest("GET", "/schemas?schema_name=public", nil)
 		w := httptest.NewRecorder()
 		So(err, ShouldBeNil)
-		validate(w, r, GetSchemas)
+		validate(w, r, GetSchemas, "TestGetSchemas")
 	})
 
 	Convey("Get schemas with custom where clause and pagination", t, func() {
 		r, err := http.NewRequest("GET", "/schemas?schema_name=public&_page=1&_page_size=20", nil)
 		w := httptest.NewRecorder()
 		So(err, ShouldBeNil)
-		validate(w, r, GetSchemas)
+		validate(w, r, GetSchemas, "TestGetSchemas")
 	})
 }

--- a/controllers/tables.go
+++ b/controllers/tables.go
@@ -61,6 +61,7 @@ func GetTablesByDatabaseAndSchema(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	sqlSchemaTables := statements.SchemaTables
@@ -123,6 +124,7 @@ func SelectFromTables(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	sqlSelect := query
@@ -214,6 +216,7 @@ func DeleteFromTable(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	object, err := postgres.Delete(database, schema, table, where, values)
@@ -260,6 +263,7 @@ func UpdateTable(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	object, err := postgres.Update(database, schema, table, where, values, req)

--- a/controllers/tables.go
+++ b/controllers/tables.go
@@ -61,7 +61,14 @@ func GetTablesByDatabaseAndSchema(w http.ResponseWriter, r *http.Request) {
 			requestWhere,
 			statements.SchemaTablesOrderBy)
 	}
-	sqlSchemaTables = fmt.Sprint(sqlSchemaTables, " ", postgres.PaginateIfPossible(r))
+
+	page, err := postgres.PaginateIfPossible(r)
+	if err != nil {
+		http.Error(w, "Paging error", http.StatusBadRequest)
+		return
+	}
+
+	sqlSchemaTables = fmt.Sprint(sqlSchemaTables, " ", page)
 
 	valuesAux := make([]interface{}, 0)
 	valuesAux = append(valuesAux, database)
@@ -109,7 +116,13 @@ func SelectFromTables(w http.ResponseWriter, r *http.Request) {
 			" WHERE ",
 			requestWhere)
 	}
-	sqlSelect = fmt.Sprint(sqlSelect, " ", postgres.PaginateIfPossible(r))
+
+	page, err := postgres.PaginateIfPossible(r)
+	if err != nil {
+		http.Error(w, "Paging error", http.StatusBadRequest)
+		return
+	}
+	sqlSelect = fmt.Sprint(sqlSelect, " ", page)
 
 	object, err := postgres.Query(sqlSelect, values...)
 	if err != nil {

--- a/controllers/tables.go
+++ b/controllers/tables.go
@@ -222,8 +222,8 @@ func UpdateTable(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	n := len(req.Data) + 1
-	where, values := postgres.WhereByRequest(r, n)
+
+	where, values := postgres.WhereByRequest(r, 1)
 
 	object, err := postgres.Update(database, schema, table, where, values, req)
 	if err != nil {

--- a/controllers/tables.go
+++ b/controllers/tables.go
@@ -19,6 +19,7 @@ func GetTables(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	sqlTables := statements.Tables

--- a/controllers/tables.go
+++ b/controllers/tables.go
@@ -15,7 +15,12 @@ import (
 
 // GetTables list all (or filter) tables
 func GetTables(w http.ResponseWriter, r *http.Request) {
-	requestWhere, values := postgres.WhereByRequest(r, 1)
+	requestWhere, values, err := postgres.WhereByRequest(r, 1)
+	if err != nil {
+		log.Println(err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+
 	sqlTables := statements.Tables
 	if requestWhere != "" {
 		sqlTables = fmt.Sprint(
@@ -51,7 +56,12 @@ func GetTablesByDatabaseAndSchema(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Unable to parse schema in URI", http.StatusInternalServerError)
 		return
 	}
-	requestWhere, values := postgres.WhereByRequest(r, 3)
+	requestWhere, values, err := postgres.WhereByRequest(r, 3)
+	if err != nil {
+		log.Println(err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+
 	sqlSchemaTables := statements.SchemaTables
 	if requestWhere != "" {
 		sqlSchemaTables = fmt.Sprint(
@@ -108,7 +118,12 @@ func SelectFromTables(w http.ResponseWriter, r *http.Request) {
 	}
 
 	query := fmt.Sprintf("%s %s.%s.%s", statements.SelectInTable, database, schema, table)
-	requestWhere, values := postgres.WhereByRequest(r, 1)
+	requestWhere, values, err := postgres.WhereByRequest(r, 1)
+	if err != nil {
+		log.Println(err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+
 	sqlSelect := query
 	if requestWhere != "" {
 		sqlSelect = fmt.Sprint(
@@ -194,7 +209,11 @@ func DeleteFromTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	where, values := postgres.WhereByRequest(r, 1)
+	where, values, err := postgres.WhereByRequest(r, 1)
+	if err != nil {
+		log.Println(err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
 
 	object, err := postgres.Delete(database, schema, table, where, values)
 	if err != nil {
@@ -236,7 +255,11 @@ func UpdateTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	where, values := postgres.WhereByRequest(r, 1)
+	where, values, err := postgres.WhereByRequest(r, 1)
+	if err != nil {
+		log.Println(err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
 
 	object, err := postgres.Update(database, schema, table, where, values, req)
 	if err != nil {

--- a/controllers/tables.go
+++ b/controllers/tables.go
@@ -15,7 +15,7 @@ import (
 
 // GetTables list all (or filter) tables
 func GetTables(w http.ResponseWriter, r *http.Request) {
-	requestWhere := postgres.WhereByRequest(r)
+	requestWhere, values := postgres.WhereByRequest(r, 1)
 	sqlTables := statements.Tables
 	if requestWhere != "" {
 		sqlTables = fmt.Sprint(
@@ -26,7 +26,7 @@ func GetTables(w http.ResponseWriter, r *http.Request) {
 			statements.TablesOrderBy)
 	}
 
-	object, err := postgres.Query(sqlTables)
+	object, err := postgres.Query(sqlTables, values)
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -51,7 +51,7 @@ func GetTablesByDatabaseAndSchema(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Unable to parse schema in URI", http.StatusInternalServerError)
 		return
 	}
-	requestWhere := postgres.WhereByRequest(r)
+	requestWhere, values := postgres.WhereByRequest(r, 3)
 	sqlSchemaTables := statements.SchemaTables
 	if requestWhere != "" {
 		sqlSchemaTables = fmt.Sprint(
@@ -63,7 +63,7 @@ func GetTablesByDatabaseAndSchema(w http.ResponseWriter, r *http.Request) {
 	}
 	sqlSchemaTables = fmt.Sprint(sqlSchemaTables, " ", postgres.PaginateIfPossible(r))
 
-	object, err := postgres.Query(sqlSchemaTables, database, schema)
+	object, err := postgres.Query(sqlSchemaTables, database, schema, values)
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -96,7 +96,7 @@ func SelectFromTables(w http.ResponseWriter, r *http.Request) {
 	}
 
 	query := fmt.Sprintf("%s %s.%s.%s", statements.SelectInTable, database, schema, table)
-	requestWhere := postgres.WhereByRequest(r)
+	requestWhere, values := postgres.WhereByRequest(r, 1)
 	sqlSelect := query
 	if requestWhere != "" {
 		sqlSelect = fmt.Sprint(
@@ -106,7 +106,7 @@ func SelectFromTables(w http.ResponseWriter, r *http.Request) {
 	}
 	sqlSelect = fmt.Sprint(sqlSelect, " ", postgres.PaginateIfPossible(r))
 
-	object, err := postgres.Query(sqlSelect)
+	object, err := postgres.Query(sqlSelect, values)
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -176,7 +176,7 @@ func DeleteFromTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	where := postgres.WhereByRequest(r)
+	where, values := postgres.WhereByRequest(r, 1)
 
 	object, err := postgres.Delete(database, schema, table, where)
 	if err != nil {
@@ -210,7 +210,7 @@ func UpdateTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	where := postgres.WhereByRequest(r)
+	where, values := postgres.WhereByRequest(r, 1)
 	req := api.Request{}
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {

--- a/controllers/tables_test.go
+++ b/controllers/tables_test.go
@@ -15,21 +15,21 @@ func TestGetTables(t *testing.T) {
 		r, err := http.NewRequest("GET", "/tables", nil)
 		w := httptest.NewRecorder()
 		So(err, ShouldBeNil)
-		validate(w, r, GetTables)
+		validate(w, r, GetTables, "TestGetTables")
 	})
 
 	Convey("Get tables with custom where clause", t, func() {
 		r, err := http.NewRequest("GET", "/tables?c.relname=test", nil)
 		w := httptest.NewRecorder()
 		So(err, ShouldBeNil)
-		validate(w, r, GetTables)
+		validate(w, r, GetTables, "TestGetTables")
 	})
 
 	Convey("Get tables with custom where clause and pagination", t, func() {
 		r, err := http.NewRequest("GET", "/tables?c.relname=test&_page=1&_page_size=20", nil)
 		w := httptest.NewRecorder()
 		So(err, ShouldBeNil)
-		validate(w, r, GetTables)
+		validate(w, r, GetTables, "TestGetTables")
 	})
 }
 
@@ -39,15 +39,15 @@ func TestGetTablesByDatabaseAndSchema(t *testing.T) {
 	server := httptest.NewServer(router)
 	defer server.Close()
 	Convey("Get tables by database and schema without custom where clause", t, func() {
-		doValidGetRequest(server.URL + "/prest/public")
+		doValidGetRequest(server.URL+"/prest/public", "GetTablesByDatabaseAndSchema")
 	})
 
 	Convey("Get tables by database and schema with custom where clause", t, func() {
-		doValidGetRequest(server.URL + "/prest/public?t.tablename=test")
+		doValidGetRequest(server.URL+"/prest/public?t.tablename=test", "GetTablesByDatabaseAndSchema")
 	})
 
 	Convey("Get tables by database and schema with custom where clause and pagination", t, func() {
-		doValidGetRequest(server.URL + "/prest/public?t.tablename=test&_page=1&_page_size=20")
+		doValidGetRequest(server.URL+"/prest/public?t.tablename=test&_page=1&_page_size=20", "GetTablesByDatabaseAndSchema")
 	})
 }
 
@@ -57,15 +57,15 @@ func TestSelectFromTables(t *testing.T) {
 	server := httptest.NewServer(router)
 	defer server.Close()
 	Convey("execute select in a table without custom where clause", t, func() {
-		doValidGetRequest(server.URL + "/prest/public/test")
+		doValidGetRequest(server.URL+"/prest/public/test", "SelectFromTables")
 	})
 
 	Convey("execute select in a table with custom where clause", t, func() {
-		doValidGetRequest(server.URL + "/prest/public/test?name=nuveo")
+		doValidGetRequest(server.URL+"/prest/public/test?name=nuveo", "SelectFromTables")
 	})
 
 	Convey("execute select in a table with custom where clause and pagination", t, func() {
-		doValidGetRequest(server.URL + "/prest/public/test?name=nuveo&_page=1&_page_size=20")
+		doValidGetRequest(server.URL+"/prest/public/test?name=nuveo&_page=1&_page_size=20", "SelectFromTables")
 	})
 }
 
@@ -90,10 +90,10 @@ func TestDeleteFromTable(t *testing.T) {
 	server := httptest.NewServer(router)
 	defer server.Close()
 	Convey("excute delete in a table without where clause", t, func() {
-		doValidDeleteRequest(server.URL + "/prest/public/test")
+		doValidDeleteRequest(server.URL+"/prest/public/test", "DeleteFromTable")
 	})
 	Convey("excute delete in a table with where clause", t, func() {
-		doValidDeleteRequest(server.URL + "/prest/public/test?name=nuveo")
+		doValidDeleteRequest(server.URL+"/prest/public/test?name=nuveo", "DeleteFromTable")
 	})
 }
 

--- a/controllers/tables_test.go
+++ b/controllers/tables_test.go
@@ -15,21 +15,21 @@ func TestGetTables(t *testing.T) {
 		r, err := http.NewRequest("GET", "/tables", nil)
 		w := httptest.NewRecorder()
 		So(err, ShouldBeNil)
-		validate(w, r, GetTables, "TestGetTables")
+		validate(w, r, GetTables, "TestGetTables1")
 	})
 
 	Convey("Get tables with custom where clause", t, func() {
 		r, err := http.NewRequest("GET", "/tables?c.relname=test", nil)
 		w := httptest.NewRecorder()
 		So(err, ShouldBeNil)
-		validate(w, r, GetTables, "TestGetTables")
+		validate(w, r, GetTables, "TestGetTables2")
 	})
 
 	Convey("Get tables with custom where clause and pagination", t, func() {
 		r, err := http.NewRequest("GET", "/tables?c.relname=test&_page=1&_page_size=20", nil)
 		w := httptest.NewRecorder()
 		So(err, ShouldBeNil)
-		validate(w, r, GetTables, "TestGetTables")
+		validate(w, r, GetTables, "TestGetTables3")
 	})
 }
 

--- a/controllers/tables_test.go
+++ b/controllers/tables_test.go
@@ -80,7 +80,7 @@ func TestInsertInTables(t *testing.T) {
 				"name": "prest",
 			},
 		}
-		doValidPostRequest(server.URL+"/prest/public/test", r)
+		doValidPostRequest(server.URL+"/prest/public/test", r, "InsertInTables")
 	})
 }
 
@@ -108,15 +108,15 @@ func TestUpdateFromTable(t *testing.T) {
 		},
 	}
 	Convey("excute update in a table without where clause using PUT", t, func() {
-		doValidPutRequest(server.URL+"/prest/public/test", r)
+		doValidPutRequest(server.URL+"/prest/public/test", r, "UpdateTable")
 	})
 	Convey("excute update in a table with where clause using PUT", t, func() {
-		doValidPutRequest(server.URL+"/prest/public/test?name=nuveo", r)
+		doValidPutRequest(server.URL+"/prest/public/test?name=nuveo", r, "UpdateTable")
 	})
 	Convey("excute update in a table without where clause using PATCH", t, func() {
-		doValidPatchRequest(server.URL+"/prest/public/test", r)
+		doValidPatchRequest(server.URL+"/prest/public/test", r, "UpdateTable")
 	})
 	Convey("excute update in a table with where clause using PATCH", t, func() {
-		doValidPatchRequest(server.URL+"/prest/public/test?name=nuveo", r)
+		doValidPatchRequest(server.URL+"/prest/public/test?name=nuveo", r, "UpdateTable")
 	})
 }

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -13,14 +14,16 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func validate(w *httptest.ResponseRecorder, r *http.Request, h http.HandlerFunc) {
+func validate(w *httptest.ResponseRecorder, r *http.Request, h http.HandlerFunc, where string) {
 	h(w, r)
+	fmt.Println("Test:", where)
 	So(w.Code, ShouldEqual, 200)
 	_, err := ioutil.ReadAll(w.Body)
 	So(err, ShouldBeNil)
 }
 
-func doValidGetRequest(url string) {
+func doValidGetRequest(url string, where string) {
+	fmt.Println("Test:", where)
 	resp, err := http.Get(url)
 	So(err, ShouldBeNil)
 	So(resp.StatusCode, ShouldEqual, 200)
@@ -38,7 +41,8 @@ func doValidPostRequest(url string, r api.Request) {
 	So(err, ShouldBeNil)
 }
 
-func doValidDeleteRequest(url string) {
+func doValidDeleteRequest(url string, where string) {
+	fmt.Println("Test:", where)
 	req, err := http.NewRequest("DELETE", url, nil)
 	So(err, ShouldBeNil)
 	client := &http.Client{}

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -31,7 +31,8 @@ func doValidGetRequest(url string, where string) {
 	So(err, ShouldBeNil)
 }
 
-func doValidPostRequest(url string, r api.Request) {
+func doValidPostRequest(url string, r api.Request, where string) {
+	fmt.Println("Test:", where)
 	byt, err := json.Marshal(r)
 	So(err, ShouldBeNil)
 	resp, err := http.Post(url, "application/json", bytes.NewBuffer(byt))
@@ -53,7 +54,8 @@ func doValidDeleteRequest(url string, where string) {
 	So(err, ShouldBeNil)
 }
 
-func doValidPutRequest(url string, r api.Request) {
+func doValidPutRequest(url string, r api.Request, where string) {
+	fmt.Println("Test:", where)
 	byt, err := json.Marshal(r)
 	So(err, ShouldBeNil)
 	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(byt))
@@ -66,7 +68,8 @@ func doValidPutRequest(url string, r api.Request) {
 	So(err, ShouldBeNil)
 }
 
-func doValidPatchRequest(url string, r api.Request) {
+func doValidPatchRequest(url string, r api.Request, where string) {
+	fmt.Println("Test:", where)
 	byt, err := json.Marshal(r)
 	So(err, ShouldBeNil)
 	req, err := http.NewRequest("PATCH", url, bytes.NewBuffer(byt))


### PR DESCRIPTION
Prevents SQL injection as mentioned in issue #36 (SQL injection is possible) as well other cases where failure could occur.

To correct the problem:
- The SQL calls are now made using prepare statement.
- The paging parameters only accept numbers.
- Where possible the identifiers are validated.