### PR TITLE
Add transactions in SQL operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,15 @@ before_install:
 
 before_script:
     - psql -c "create database prest;" -U postgres
-    - psql prest -c "create table test(name text);" -U postgres
+    - psql prest -c "create table test(id serial, name text);" -U postgres
     - psql prest -c "create table test2(name text, number integer);" -U postgres
+    - psql prest -c "create table test3(id serial, name text UNIQUE);" -U postgres
+    - psql prest -c "create table test4(id serial, name text UNIQUE);" -U postgres
     - psql prest -c "insert into test (name) values ('prest tester');" -U postgres
     - psql prest -c "insert into test (name) values ('tester02');" -U postgres
     - psql prest -c "insert into test2 (name, number) values ('tester02', 2);" -U postgres
+    - psql prest -c "insert into test3 (name) values ('prest');" -U postgres
+    - psql prest -c "insert into test3 (name) values ('prest tester');" -U postgres
 
 script:
     - sh test.sh

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
@@ -79,9 +80,25 @@ func TestInsert(t *testing.T) {
 		r := api.Request{
 			Data: m,
 		}
-		json, err := Insert("prest", "public", "test", r)
+		jsonByte, err := Insert("prest", "public", "test4", r)
 		So(err, ShouldBeNil)
-		So(len(json), ShouldBeGreaterThan, 0)
+		So(len(jsonByte), ShouldBeGreaterThan, 0)
+
+		var toJson map[string]interface{}
+		err = json.Unmarshal(jsonByte, &toJson)
+
+		So(toJson["id"], ShouldEqual, 1)
+	})
+
+	Convey("Insert data into a table with contraints", t, func() {
+		m := make(map[string]interface{}, 0)
+		m["name"] = "prest"
+
+		r := api.Request{
+			Data: m,
+		}
+		_, err := Insert("prest", "public", "test3", r)
+		So(err, ShouldNotBeNil)
 	})
 }
 
@@ -105,6 +122,17 @@ func TestUpdate(t *testing.T) {
 		json, err := Update("prest", "public", "test", "name=$1", []interface{}{"prest"}, r)
 		So(err, ShouldBeNil)
 		So(len(json), ShouldBeGreaterThan, 0)
+	})
+
+	Convey("Update data into a table with constraints", t, func() {
+		m := make(map[string]interface{}, 0)
+		m["name"] = "prest"
+
+		r := api.Request{
+			Data: m,
+		}
+		_, err := Update("prest", "public", "test3", "name=$1", []interface{}{"prest tester"}, r)
+		So(err, ShouldNotBeNil)
 	})
 }
 


### PR DESCRIPTION
A PostgreSQL library does not support the result Result.LastInsertId()[1],
here we will use a RETURNING syntax as recommended by own community [2].

[1] https://golang.org/pkg/database/sql/#Result
[2] https://github.com/lib/pq/issues/24

closes #48 