### PR TITLE
Added version command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
+COMMIT_HASH=`git rev-parse --short HEAD>/dev/null`
 DIST := dist
 IMPORT := github.com/nuveo/prest
-LDFLAGS := -X "main.Version=$(shell git describe --tags --always | sed 's/-/+/' | sed 's/^v//')"
+LDFLAGS := -X "github.com/nuveo/prest/helpers/prest.CommitHash=${COMMIT_HASH}"
 OUT := 'prest'
 TARGETS ?= linux/*,darwin/*,windows/*
 

--- a/cmd/mversion.go
+++ b/cmd/mversion.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mattes/migrate/migrate"
+	// postgres driver for migrate
+	_ "github.com/mattes/migrate/driver/postgres"
+	"github.com/spf13/cobra"
+)
+
+// mversionCmd represents the version command
+var mversionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show the current migration version",
+	Long:  `Show the current migration version`,
+	Run: func(cmd *cobra.Command, args []string) {
+		verifyMigrationsPath(path)
+		version, err := migrate.Version(url, path)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(-1)
+		}
+		fmt.Println(version)
+	},
+}
+
+func init() {
+	migrateCmd.AddCommand(mversionCmd)
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,30 +2,23 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/mattes/migrate/migrate"
 	// postgres driver for migrate
 	_ "github.com/mattes/migrate/driver/postgres"
+	"github.com/nuveo/prest/helpers"
 	"github.com/spf13/cobra"
 )
 
-// versionCmd represents the version command
+// versionCmd show version pREST
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Show the current migration version",
-	Long:  `Show the current migration version`,
+	Short: "Print the version number of pREST",
+	Long:  `All software has versions. This is pREST's`,
 	Run: func(cmd *cobra.Command, args []string) {
-		verifyMigrationsPath(path)
-		version, err := migrate.Version(url, path)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(-1)
-		}
-		fmt.Println(version)
+		fmt.Println("Serve a RESTful API from any PostgreSQL database", helpers.PrestReleaseVersion())
 	},
 }
 
 func init() {
-	migrateCmd.AddCommand(versionCmd)
+	RootCmd.AddCommand(versionCmd)
 }

--- a/helpers/prest.go
+++ b/helpers/prest.go
@@ -1,0 +1,18 @@
+package helpers
+
+import "fmt"
+
+const (
+	// Major and minor version.
+	PrestVersionNumber = 0.1
+
+	// Increment this for bug releases
+	PrestPatchVersion = 4
+)
+
+var CommitHash string
+
+// PrestReleaseVersion is same as pREST Version.
+func PrestReleaseVersion() string {
+	return fmt.Sprintf("%.2g.%d", PrestVersionNumber, PrestPatchVersion)
+}

--- a/main.go
+++ b/main.go
@@ -1,11 +1,6 @@
 package main
 
-import (
-	"github.com/nuveo/prest/cmd"
-)
-
-// Version pREST
-var Version = "0.1.3"
+import "github.com/nuveo/prest/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
Show pREST version
```
$ ./prest version
You are running pREST in public mode.
Serve a RESTful API from any PostgreSQL database 0.1.4

$ ./prest migrate version
You are running pREST in public mode.
Please specify path
exit status 255
```