### PR TITLE
Remove prepare from queries scripts

### DIFF
--- a/adapters/postgres/queries.go
+++ b/adapters/postgres/queries.go
@@ -52,8 +52,7 @@ func ParseScript(scriptPath string, queryURL url.Values) (sqlQuery string, value
 	q := make(map[string]string)
 	pid := 1
 	for key := range queryURL {
-		q[key] = fmt.Sprintf("$%d", pid)
-		values = append(values, queryURL.Get(key))
+		q[key] = fmt.Sprintf("%s", queryURL.Get(key))
 		pid++
 	}
 

--- a/adapters/postgres/queries.go
+++ b/adapters/postgres/queries.go
@@ -94,6 +94,7 @@ func WriteSQL(sql string, values []interface{}) (resultByte []byte, err error) {
 	result, err := tx.Exec(sql, valuesAux...)
 	if err != nil {
 		tx.Rollback()
+		log.Printf("sql = %+v\n", sql)
 		err = fmt.Errorf("could not peform sql: %v", err)
 		return
 	}

--- a/adapters/postgres/queries_test.go
+++ b/adapters/postgres/queries_test.go
@@ -82,7 +82,7 @@ func TestParseScript(t *testing.T) {
 		t.Errorf("expected no error, but got: %v", err)
 	}
 
-	if sql != "SELECT * FROM test7 WHERE name = abc" {
+	if sql != "SELECT * FROM test7 WHERE name = 'abc'" {
 		t.Errorf("SQL unexpected, got: %s", sql)
 	}
 

--- a/adapters/postgres/queries_test.go
+++ b/adapters/postgres/queries_test.go
@@ -77,7 +77,7 @@ func TestParseScript(t *testing.T) {
 	scriptPath := fmt.Sprint(user.HomeDir, "/queries/fulltable/%s")
 
 	t.Log("Parse script with get_all file")
-	sql, values, err := ParseScript(fmt.Sprintf(scriptPath, "get_all.read.sql"), queryURL)
+	sql, _, err := ParseScript(fmt.Sprintf(scriptPath, "get_all.read.sql"), queryURL)
 	if err != nil {
 		t.Errorf("expected no error, but got: %v", err)
 	}
@@ -86,40 +86,28 @@ func TestParseScript(t *testing.T) {
 		t.Errorf("SQL unexpected, got: %s", sql)
 	}
 
-	if len(values) != 1 && values[0] != "abc" {
-		t.Errorf("values unexpected, got: %v", values)
-	}
-
 	// Add new values
 	queryURL.Del("field1")
 	queryURL.Set("notable", "123")
 
 	t.Log("Try Parse Script with invalid params")
-	sql, values, err = ParseScript(fmt.Sprintf(scriptPath, "get_all.read.sql"), queryURL)
+	sql, _, err = ParseScript(fmt.Sprintf(scriptPath, "get_all.read.sql"), queryURL)
 	if err == nil {
 		t.Errorf("expected error, but got: %v", err)
 	}
 
 	if sql != "" {
 		t.Errorf("expected empty string, got: %s", sql)
-	}
-
-	if len(values) != 1 && values[0] != "123" {
-		t.Errorf("values unexpected, got: %v", values)
 	}
 
 	t.Log("Try Parse Script with noexistent script")
-	sql, values, err = ParseScript(fmt.Sprintf(scriptPath, "gt_all.read.sql"), queryURL)
+	sql, _, err = ParseScript(fmt.Sprintf(scriptPath, "gt_all.read.sql"), queryURL)
 	if err == nil {
 		t.Errorf("expected error, but got: %v", err)
 	}
 
 	if sql != "" {
 		t.Errorf("expected empty string, got: %s", sql)
-	}
-
-	if len(values) != 0 {
-		t.Errorf("values unexpected, got: %v", values)
 	}
 }
 
@@ -130,9 +118,9 @@ func TestValidWriteSQL(t *testing.T) {
 		values      []interface{}
 		err         error
 	}{
-		{"Execute a valid INSERT sql", "INSERT INTO test7 (name) values (lulu)", []interface{}{"lulu"}, nil},
-		{"Execute a valid UPDATE sql", "UPDATE test7 SET name = lulu WHERE surname = temer", []interface{}{"lulu", "temer"}, nil},
-		{"Execute a valid DELETE sql", "DELETE FROM test7 WHERE name = lulu", []interface{}{"lulu"}, nil},
+		{"Execute a valid INSERT sql", "INSERT INTO test7(name) values ('lulu')", []interface{}{}, nil},
+		{"Execute a valid UPDATE sql", "UPDATE test7 SET name = 'lulu' WHERE surname = 'temer'", []interface{}{}, nil},
+		{"Execute a valid DELETE sql", "DELETE FROM test7 WHERE name = 'lulu'", []interface{}{}, nil},
 	}
 	for _, tc := range testValidCases {
 		t.Log(tc.description)
@@ -149,9 +137,9 @@ func TestInvalidWriteSQL(t *testing.T) {
 		sql         string
 		values      []interface{}
 	}{
-		{"Execute an invalid INSERT sql", "INSERT INTO test7 (tool) values (lulu)", []interface{}{"lulu"}},
-		{"Execute an invalid UPDATE sql", "UPDATE test7 SET name = lulu WHERE surname =", []interface{}{"lulu"}},
-		{"Execute an invalid DELETE sql", "DELETE FROM test7 WHERE name = lulu AND surname =", []interface{}{"lulu"}},
+		{"Execute an invalid INSERT sql", "INSERT INTO test7 (tool) values (lulu)", []interface{}{}},
+		{"Execute an invalid UPDATE sql", "UPDATE test7 SET name = lulu WHERE surname =", []interface{}{}},
+		{"Execute an invalid DELETE sql", "DELETE FROM test7 WHERE name = lulu AND surname =", []interface{}{}},
 	}
 
 	for _, tc := range testInvalidCases {
@@ -172,10 +160,10 @@ func TestExecuteScripts(t *testing.T) {
 		err         error
 	}{
 		{"Get result with GET HTTP Method", "GET", "SELECT * FROM test7", []interface{}{}, nil},
-		{"Get result with POST HTTP Method", "POST", "INSERT INTO test7 (name) VALUES (lala)", []interface{}{"lala"}, nil},
-		{"Get result with PUT HTTP Method", "PUT", "UPDATE test7 SET name = lala WHERE surname = temer", []interface{}{"lala", "temer"}, nil},
-		{"Get result with PATCH HTTP Method", "PATCH", "UPDATE test7 SET surname = temer WHERE name = lala", []interface{}{"temer", "lala"}, nil},
-		{"Get result with DELETE HTTP Method", "DELETE", "DELETE FROM test7 WHERE surname = lala", []interface{}{"lala"}, nil},
+		{"Get result with POST HTTP Method", "POST", "INSERT INTO test7 (name) VALUES ('lala')", []interface{}{}, nil},
+		{"Get result with PUT HTTP Method", "PUT", "UPDATE test7 SET name = 'lala' WHERE surname = 'temer'", []interface{}{}, nil},
+		{"Get result with PATCH HTTP Method", "PATCH", "UPDATE test7 SET surname = 'temer' WHERE name = 'lala'", []interface{}{}, nil},
+		{"Get result with DELETE HTTP Method", "DELETE", "DELETE FROM test7 WHERE surname = 'lala'", []interface{}{}, nil},
 	}
 
 	for _, tc := range testCases {

--- a/adapters/postgres/queries_test.go
+++ b/adapters/postgres/queries_test.go
@@ -82,7 +82,7 @@ func TestParseScript(t *testing.T) {
 		t.Errorf("expected no error, but got: %v", err)
 	}
 
-	if sql != "SELECT * FROM test7 WHERE name = $1" {
+	if sql != "SELECT * FROM test7 WHERE name = abc" {
 		t.Errorf("SQL unexpected, got: %s", sql)
 	}
 
@@ -130,9 +130,9 @@ func TestValidWriteSQL(t *testing.T) {
 		values      []interface{}
 		err         error
 	}{
-		{"Execute a valid INSERT sql", "INSERT INTO test7 (name) values ($1)", []interface{}{"lulu"}, nil},
-		{"Execute a valid UPDATE sql", "UPDATE test7 SET name = $1 WHERE surname = $2", []interface{}{"lulu", "temer"}, nil},
-		{"Execute a valid DELETE sql", "DELETE FROM test7 WHERE name = $1", []interface{}{"lulu"}, nil},
+		{"Execute a valid INSERT sql", "INSERT INTO test7 (name) values (lulu)", []interface{}{"lulu"}, nil},
+		{"Execute a valid UPDATE sql", "UPDATE test7 SET name = lulu WHERE surname = temer", []interface{}{"lulu", "temer"}, nil},
+		{"Execute a valid DELETE sql", "DELETE FROM test7 WHERE name = lulu", []interface{}{"lulu"}, nil},
 	}
 	for _, tc := range testValidCases {
 		t.Log(tc.description)
@@ -149,9 +149,9 @@ func TestInvalidWriteSQL(t *testing.T) {
 		sql         string
 		values      []interface{}
 	}{
-		{"Execute an invalid INSERT sql", "INSERT INTO test7 (tool) values ($1)", []interface{}{"lulu"}},
-		{"Execute an invalid UPDATE sql", "UPDATE test7 SET name = $1 WHERE surname = $2", []interface{}{"lulu"}},
-		{"Execute an invalid DELETE sql", "DELETE FROM test7 WHERE name = $1 AND surname = $2", []interface{}{"lulu"}},
+		{"Execute an invalid INSERT sql", "INSERT INTO test7 (tool) values (lulu)", []interface{}{"lulu"}},
+		{"Execute an invalid UPDATE sql", "UPDATE test7 SET name = lulu WHERE surname =", []interface{}{"lulu"}},
+		{"Execute an invalid DELETE sql", "DELETE FROM test7 WHERE name = lulu AND surname =", []interface{}{"lulu"}},
 	}
 
 	for _, tc := range testInvalidCases {
@@ -172,10 +172,10 @@ func TestExecuteScripts(t *testing.T) {
 		err         error
 	}{
 		{"Get result with GET HTTP Method", "GET", "SELECT * FROM test7", []interface{}{}, nil},
-		{"Get result with POST HTTP Method", "POST", "INSERT INTO test7 (name) VALUES ($1)", []interface{}{"lala"}, nil},
-		{"Get result with PUT HTTP Method", "PUT", "UPDATE test7 SET name = $1 WHERE surname = $2", []interface{}{"lala", "temer"}, nil},
-		{"Get result with PATCH HTTP Method", "PATCH", "UPDATE test7 SET surname = $1 WHERE name = $2", []interface{}{"temer", "lala"}, nil},
-		{"Get result with DELETE HTTP Method", "DELETE", "DELETE FROM test7 WHERE surname = $1", []interface{}{"lala"}, nil},
+		{"Get result with POST HTTP Method", "POST", "INSERT INTO test7 (name) VALUES (lala)", []interface{}{"lala"}, nil},
+		{"Get result with PUT HTTP Method", "PUT", "UPDATE test7 SET name = lala WHERE surname = temer", []interface{}{"lala", "temer"}, nil},
+		{"Get result with PATCH HTTP Method", "PATCH", "UPDATE test7 SET surname = temer WHERE name = lala", []interface{}{"temer", "lala"}, nil},
+		{"Get result with DELETE HTTP Method", "DELETE", "DELETE FROM test7 WHERE surname = lala", []interface{}{"lala"}, nil},
 	}
 
 	for _, tc := range testCases {

--- a/adapters/postgres/utils_test.go
+++ b/adapters/postgres/utils_test.go
@@ -61,12 +61,12 @@ func writeMockScripts(base string) {
 		}
 	}
 
-	write("SELECT * FROM test7 WHERE name = {{.field1}}", "get_all.read.sql")
-	write("INSERT INTO test7 (name, surname) VALUES ({{.field1}}, {{.field2}})", "write_all.write.sql")
+	write("SELECT * FROM test7 WHERE name = '{{.field1}}'", "get_all.read.sql")
+	write("INSERT INTO test7 (name, surname) VALUES ('{{.field1}}', '{{.field2}}')", "write_all.write.sql")
 	write("CREATE TABLE {{.field1}};", "create_table.write.sql")
-	write("UPDATE test7 SET name = {{.field1}} WHERE surname = {{.field2}}", "patch_all.update.sql")
-	write("UPDATE test7 SET surname = {{.field1}} WHERE name = {{.field2}}", "put_all.update.sql")
-	write("DELETE FROM test7 WHERE name = {{.field1}}", "delete_all.delete.sql")
+	write("UPDATE test7 SET name = '{{.field1}}' WHERE surname = '{{.field2}}'", "patch_all.update.sql")
+	write("UPDATE test7 SET surname = '{{.field1}}' WHERE name = '{{.field2}}'", "put_all.update.sql")
+	write("DELETE FROM test7 WHERE name = '{{.field1}}'", "delete_all.delete.sql")
 }
 
 func removeMockScripts(base string) {

--- a/config/config.go
+++ b/config/config.go
@@ -51,6 +51,10 @@ func init() {
 	load()
 }
 
+func LoadToTest() {
+	load()
+}
+
 func viperCfg() {
 	filePath := os.Getenv("PREST_CONF")
 	if filePath == "" {

--- a/controllers/sql_test.go
+++ b/controllers/sql_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	os.Setenv("PREST_CONF", "../testdata/prest.toml")
+	config.LoadToTest()
+
 	createMockScripts(config.PrestConf.QueriesPath)
 	writeMockScripts(config.PrestConf.QueriesPath)
 

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -242,12 +242,12 @@ func writeMockScripts(base string) {
 		}
 	}
 
-	write("SELECT * FROM test7 WHERE name = {{.field1}}", "get_all.read.sql")
-	write("INSERT INTO test7 (name, surname) VALUES ({{.field1}}, {{.field2}})", "write_all.write.sql")
+	write("SELECT * FROM test7 WHERE name = '{{.field1}}'", "get_all.read.sql")
+	write("INSERT INTO test7 (name, surname) VALUES ('{{.field1}}', '{{.field2}}')", "write_all.write.sql")
 	write("CREATE TABLE {{.field1}};", "create_table.write.sql")
-	write("UPDATE test7 SET name = {{.field1}} WHERE surname = {{.field2}}", "patch_all.update.sql")
-	write("UPDATE test7 SET surname = {{.field1}} WHERE name = {{.field2}}", "put_all.update.sql")
-	write("DELETE FROM test7 WHERE name = {{.field1}}", "delete_all.delete.sql")
+	write("UPDATE test7 SET name = '{{.field1}}' WHERE surname = '{{.field2}}'", "patch_all.update.sql")
+	write("UPDATE test7 SET surname = '{{.field1}}' WHERE name = '{{.field2}}'", "put_all.update.sql")
+	write("DELETE FROM test7 WHERE name = '{{.field1}}'", "delete_all.delete.sql")
 }
 
 func removeMockScripts(base string) {


### PR DESCRIPTION
Assume it scripts written by users are `prepared` by default.

This it's a bug in feature `queries/scripts`.

e.g: If my script is an insert with JSONB statements, `$1` not work.
_http POST :3000/_QUERIES/foo/awesome_foo?field1=value_
```sql
INSERT INTO table_with_jsonb (data) VALUES ('{"names": ["{{.field1}}"]}');
```
After parse:
```sql
INSERT INTO table_with_jsonb (data) VALUES ('{"names": ["$1"]}');
```
 To json statements should be use `?`. But today, JSON/JSONB insert's not work in "default" REST insert _(POST method)_.

So, I remove this unecessary feature on `queries/scripts` to this `prepared` values are changed to default values:

After parse:
_http POST :3000/_QUERIES/foo/awesome_foo?field1=value_
```sql
INSERT INTO table_with_jsonb (data) VALUES ('{"names": ["value]}');
```
