### PR TITLE
Prevents multiple startup when the pREST is used as a package.

### DIFF
--- a/adapters/postgres/connection/conn_test.go
+++ b/adapters/postgres/connection/conn_test.go
@@ -4,7 +4,12 @@ import (
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	config "github.com/nuveo/prest/config"
 )
+
+func init() {
+	config.Load()
+}
 
 func TestGet(t *testing.T) {
 	t.Log("Open connection")

--- a/adapters/postgres/queries_test.go
+++ b/adapters/postgres/queries_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	config.Load()
 	createMockScripts(config.PrestConf.QueriesPath)
 	writeMockScripts(config.PrestConf.QueriesPath)
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -32,7 +32,3 @@ var createCmd = &cobra.Command{
 		fmt.Println(migrationFile.DownFile.FileName)
 	},
 }
-
-func init() {
-	migrateCmd.AddCommand(createCmd)
-}

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -26,8 +26,3 @@ var downCmd = &cobra.Command{
 		}
 	},
 }
-
-func init() {
-	// prest migrate down
-	migrateCmd.AddCommand(downCmd)
-}

--- a/cmd/goto.go
+++ b/cmd/goto.go
@@ -45,7 +45,3 @@ var gotoCmd = &cobra.Command{
 
 	},
 }
-
-func init() {
-	migrateCmd.AddCommand(gotoCmd)
-}

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -24,12 +24,6 @@ var migrateCmd = &cobra.Command{
 	Long:  `Execute migration operations`,
 }
 
-func init() {
-	RootCmd.AddCommand(migrateCmd)
-	migrateCmd.PersistentFlags().StringVar(&url, "url", driverURL(), "Database driver url")
-	migrateCmd.PersistentFlags().StringVar(&path, "path", config.PrestConf.MigrationsPath, "Migrations directory")
-}
-
 func driverURL() string {
 	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable", config.PrestConf.PGUser, config.PrestConf.PGPass, config.PrestConf.PGHost, config.PrestConf.PGPort, config.PrestConf.PGDatabase)
 }

--- a/cmd/mversion.go
+++ b/cmd/mversion.go
@@ -25,7 +25,3 @@ var mversionCmd = &cobra.Command{
 		fmt.Println(version)
 	},
 }
-
-func init() {
-	migrateCmd.AddCommand(mversionCmd)
-}

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -35,7 +35,3 @@ var nextCmd = &cobra.Command{
 		}
 	},
 }
-
-func init() {
-	migrateCmd.AddCommand(nextCmd)
-}

--- a/cmd/redo.go
+++ b/cmd/redo.go
@@ -27,7 +27,3 @@ var redoCmd = &cobra.Command{
 		}
 	},
 }
-
-func init() {
-	migrateCmd.AddCommand(redoCmd)
-}

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -27,7 +27,3 @@ var resetCmd = &cobra.Command{
 		}
 	},
 }
-
-func init() {
-	migrateCmd.AddCommand(resetCmd)
-}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,6 +30,20 @@ var RootCmd = &cobra.Command{
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	config.Load()
+	migrateCmd.AddCommand(createCmd)
+	migrateCmd.AddCommand(downCmd)
+	migrateCmd.AddCommand(gotoCmd)
+	migrateCmd.AddCommand(mversionCmd)
+	migrateCmd.AddCommand(nextCmd)
+	migrateCmd.AddCommand(redoCmd)
+	migrateCmd.AddCommand(upCmd)
+	migrateCmd.AddCommand(resetCmd)
+	RootCmd.AddCommand(versionCmd)
+	RootCmd.AddCommand(migrateCmd)
+	migrateCmd.PersistentFlags().StringVar(&url, "url", driverURL(), "Database driver url")
+	migrateCmd.PersistentFlags().StringVar(&path, "path", config.PrestConf.MigrationsPath, "Migrations directory")
+
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -26,8 +26,3 @@ var upCmd = &cobra.Command{
 		}
 	},
 }
-
-func init() {
-	// prest migrate up
-	migrateCmd.AddCommand(upCmd)
-}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,7 +18,3 @@ var versionCmd = &cobra.Command{
 		fmt.Println("Serve a RESTful API from any PostgreSQL database", helpers.PrestReleaseVersion())
 	},
 }
-
-func init() {
-	RootCmd.AddCommand(versionCmd)
-}

--- a/config/config.go
+++ b/config/config.go
@@ -47,14 +47,6 @@ type Prest struct {
 // PrestConf config variable
 var PrestConf *Prest
 
-func init() {
-	load()
-}
-
-func LoadToTest() {
-	load()
-}
-
 func viperCfg() {
 	filePath := os.Getenv("PREST_CONF")
 	if filePath == "" {
@@ -113,8 +105,8 @@ func Parse(cfg *Prest) (err error) {
 	return
 }
 
-// load configuration
-func load() {
+// Load configuration
+func Load() {
 	viperCfg()
 	PrestConf = &Prest{}
 	Parse(PrestConf)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,12 +9,12 @@ import (
 func TestLoad(t *testing.T) {
 	os.Setenv("PREST_CONF", "../testdata/prest.toml")
 
-	load()
+	Load()
 	if len(PrestConf.AccessConf.Tables) < 2 {
 		t.Errorf("expected > 2, got: %d", len(PrestConf.AccessConf.Tables))
 	}
 
-	load()
+	Load()
 	if !PrestConf.AccessConf.Restrict {
 		t.Error("expected true, but got false")
 	}

--- a/config/middlewares/middlewares_test.go
+++ b/config/middlewares/middlewares_test.go
@@ -10,11 +10,16 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
+	"github.com/nuveo/prest/config"
 	"github.com/nuveo/prest/config/router"
 	"github.com/nuveo/prest/controllers"
 	"github.com/nuveo/prest/middlewares"
 	"github.com/urfave/negroni"
 )
+
+func init() {
+	config.Load()
+}
 
 func TestInitApp(t *testing.T) {
 	app = nil

--- a/controllers/sql_test.go
+++ b/controllers/sql_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestMain(m *testing.M) {
 	os.Setenv("PREST_CONF", "../testdata/prest.toml")
-	config.LoadToTest()
+	config.Load()
 
 	createMockScripts(config.PrestConf.QueriesPath)
 	writeMockScripts(config.PrestConf.QueriesPath)


### PR DESCRIPTION
Removes init functions that were started before the host system was able to load the settings.