### PR TITLE
Remove rubocop from code climate engines

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,5 @@
 ---
 engines:
-  rubocop:
-    enabled: true
   golint:
     enabled: true
   gofmt:


### PR DESCRIPTION
Only remove a ruby engine from code climate file.