### PR TITLE
remove mock

### DIFF
--- a/adapters/postgres/connection/conn.go
+++ b/adapters/postgres/connection/conn.go
@@ -5,7 +5,6 @@ import (
 
 	"database/sql"
 
-	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/jmoiron/sqlx"
 	"github.com/nuveo/prest/config"
 	// Used pg drive on sqlx
@@ -53,16 +52,4 @@ func MustGet() *sqlx.DB {
 // SetNativeDB enable to override sqlx native db
 func SetNativeDB(native *sql.DB) {
 	DB.DB = native
-}
-
-// UseMockDB mock database
-func UseMockDB(driverName string) (mock sqlmock.Sqlmock, err error) {
-	var nativeDB *sql.DB
-
-	nativeDB, mock, err = sqlmock.New()
-	if err != nil {
-		return
-	}
-	DB = sqlx.NewDb(nativeDB, driverName)
-	return
 }

--- a/adapters/postgres/connection/conn_test.go
+++ b/adapters/postgres/connection/conn_test.go
@@ -54,13 +54,3 @@ func TestSetNativeDB(t *testing.T) {
 		t.Errorf("expected same memory address, but no was! %v %v", db.DB, mockedDB)
 	}
 }
-
-func TestUseMockDB(t *testing.T) {
-	mock, err := UseMockDB("postgres")
-	if err != nil {
-		t.Errorf("expected no error, but has %v", err)
-	}
-	if mock == nil {
-		t.Error("mock is nil")
-	}
-}

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	sqlmock "github.com/DATA-DOG/go-sqlmock"
-	"github.com/nuveo/prest/adapters/postgres/connection"
 	"github.com/nuveo/prest/api"
 	"github.com/nuveo/prest/config"
 	"github.com/nuveo/prest/statements"
@@ -813,22 +811,4 @@ func TestTimeout(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error disabling statement_timeout")
 	}
-}
-
-func TestMockUsage(t *testing.T) {
-	mock, err := connection.UseMockDB("postgres")
-	if err != nil {
-		t.Errorf("expected no error, but has %v", err)
-	}
-	mock.ExpectPrepare("SELECT *").
-		ExpectQuery().
-		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(1, "prest"))
-	jsonData, err := Query("SELECT * FROM test")
-	if err != nil {
-		t.Errorf("expected no error, but has %v", err)
-	}
-	if len(jsonData) <= 0 {
-		t.Errorf("json data is empty")
-	}
-	connection.DB = nil
 }


### PR DESCRIPTION
this PR remove mock because when pREST used as  package and the other package import  sqlMock package too, this case a panic "Mock driver register twice"
```
→ go run main.go
panic: sql: Register called twice for driver sqlmock

goroutine 1 [running]:
database/sql.Register(0x191731c, 0x7, 0x1d5f8e0, 0xc420218f60)
	/usr/local/Cellar/go/1.8.3/libexec/src/database/sql/sql.go:50 +0x1bc
github.com/nuveo/middleware.core/vendor/github.com/DATA-DOG/go-sqlmock.init.1()
	/Users/sarrada/go/src/github.com/nuveo/middleware.core/vendor/github.com/DATA-DOG/go-sqlmock/driver.go:16 +0xe2
github.com/nuveo/middleware.core/vendor/github.com/DATA-DOG/go-sqlmock.init()
	/Users/sarrada/go/src/github.com/nuveo/middleware.core/vendor/github.com/DATA-DOG/go-sqlmock/util.go:14 +0xec
github.com/nuveo/middleware.core/vendor/github.com/nuveo/prest/adapters/postgres/connection.init()
	/Users/sarrada/go/src/github.com/nuveo/middleware.core/vendor/github.com/nuveo/prest/adapters/postgres/connection/conn.go:69 +0x4e
github.com/nuveo/middleware.core/vendor/github.com/nuveo/prest/adapters/postgres.init()
	/Users/sarrada/go/src/github.com/nuveo/middleware.core/vendor/github.com/nuveo/prest/adapters/postgres/queries.go:140 +0x75
github.com/nuveo/middleware.core/vendor/github.com/nuveo/auth.core/auth.init()
	/Users/sarrada/go/src/github.com/nuveo/middleware.core/vendor/github.com/nuveo/auth.core/auth/router.go:15 +0x76
github.com/nuveo/middleware%2ecore.init()
	/Users/sarrada/go/src/github.com/nuveo/middleware.core/jwt.go:20 +0x58
main.init()
	/Users/sarrada/go/src/github.com/nuveo/application.core/main.go:44 +0x67
exit status 2
```