### PR TITLE
Change key with respect to JWT token

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ migrations = "./migrations"
 port = 6000
 
 [jwt]
-key = "mysecretkey"
+key = "secret"
 
 [pg]
 host = "127.0.0.1"


### PR DESCRIPTION
Line 109 in README.md says `key = mysecretkey`, But when I decode the token provided in line number 125, the actual signature is just `secret` not `mysecretkey`. Its a very trivial refactor but it will avoid confusions when referring README.md while getting started with prest.
 
![prest](https://cloud.githubusercontent.com/assets/9973091/26770938/69fe4ca4-49d8-11e7-997b-ac21f20ffe80.png)
